### PR TITLE
FIX: run edit code editor

### DIFF
--- a/gui/neteditcc.py
+++ b/gui/neteditcc.py
@@ -360,6 +360,7 @@ def contextmenu_transition(config, item, position):
     ]
 
 def contextmenu_edge(config, item, position):
+    edge = item.owner
     menu = [ ("Delete", lambda w: delete_items(config, [item])) ]
     if item.kind == "point" is not None:
        menu.append(

--- a/gui/neteditcc.py
+++ b/gui/neteditcc.py
@@ -340,6 +340,7 @@ def resize_item(config, item, position):
     config.initial_mouse = position
 
 def contextmenu_place(config, item, position):
+    place = item.owner
     return [
         ("Resize", lambda w: resize_item(config, item, position)),
         ("Edit init code",
@@ -349,6 +350,7 @@ def contextmenu_place(config, item, position):
     ]
 
 def contextmenu_transition(config, item, position):
+    transition = item.owner
     return [
         ("Resize", lambda w: resize_item(config, item, position)),
         ("Edit code",


### PR DESCRIPTION
During my work on removing elements I destroyed opening of code editor on places and transitions. So, here is a fix.