### PR TITLE
Rc/export ctrlseq

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -366,7 +366,7 @@ class App:
     def edit_control_sequences(self):
         if self.window.switch_to_tab_by_key("sequences"):
             return
-        widget = controlseq.SequenceListWidget(self.project)
+        widget = controlseq.SequenceListWidget(self, self.project)
         self.window.add_tab(Tab(
             "Sequences", widget, "sequences",
             mainmenu_groups=("project",), call_close=True))

--- a/gui/controlseq.py
+++ b/gui/controlseq.py
@@ -222,7 +222,11 @@ class SequenceListWidget(gtk.HPaned):
                                            (gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
                                            gtk.STOCK_SAVE, gtk.RESPONSE_OK))
             dialog.set_default_response(gtk.RESPONSE_OK)
-            dialog.set_current_name(sequence.name)
+            dialog.set_current_name("{0}.skcs.xml".format(sequence.name))
+
+            skcs_filter = gtk.FileFilter() # Strict Kaira Control Sequence
+            skcs_filter.set_name("Strict Control Sequence (.skcs.xml)")
+            dialog.add_filter(skcs_filter)
 
             try:
                 response = dialog.run()
@@ -283,7 +287,6 @@ class SequenceListWidget(gtk.HPaned):
                 element.set("type", TYPE)
                 element.set("version", VERSION)
                 element.text = cmdlines
-                if not filename.endswith(".skcs.xml"):
-                    filename += ".skcs.xml" # Strict Kaira Control Sequence
+
                 tree = xml.ElementTree(element)
                 tree.write(filename)


### PR DESCRIPTION
It was implemented an exporting functionality for control sequences. The exported version differs a little from the standard one -- It is called _strict_ . It contains ID's of transitions instead of names, including: action: _transition finish_. The strict version is mainly intended on controlling the run of a resulting application (which will be implemented soon).